### PR TITLE
Checking nil or wrong data before using it

### DIFF
--- a/iqfeed.go
+++ b/iqfeed.go
@@ -138,6 +138,9 @@ func (c *IQC) processErrorMsg(d []byte) {
 
 // ProcessReceiver is one of the main reciever functions that interprets data received by IQFeed and processes it in sub functions.
 func (c *IQC) processReceiver(d []byte) {
+	if d == nil || len(d) <3 {
+		return
+	}
 	data := d[2:]
 	switch d[0] {
 	case 0x53: // Start letter is S, indicating System message (Unicode representation in integer value).


### PR DESCRIPTION
When the server starts sometimes it sends nil or empty data to the queue. If you try to use this data without checking it first you get the following error:

```bash
panic: runtime error: slice bounds out of range

goroutine 20 [running]:
github.com/Nitecon/iqfeed.(*IQC).processReceiver(0xc00008c000, 0xc0000b2978, 0x0, 0x688)
        C:/Users/XXX/go/src/github.com/Nitecon/iqfeed/iqfeed.go:141 +0x32f
github.com/Nitecon/iqfeed.(*IQC).read(0xc00008c000)
        C:/Users/XXX/go/src/github.com/Nitecon/iqfeed/iqfeed.go:181 +0x1a6
created by github.com/Nitecon/iqfeed.(*IQC).Start
        C:/Users/XXX/go/src/github.com/Nitecon/iqfeed/iqfeed.go:268 +0x1d0
exit status 2
```

With the changes in this PR we're checking the incoming data before using it.

Cheers!